### PR TITLE
Print omitted modules on the same line as ellipsis

### DIFF
--- a/src/AbbreviatedStackTraces.jl
+++ b/src/AbbreviatedStackTraces.jl
@@ -37,8 +37,10 @@ function show_compact_backtrace(io::IO, trace::Vector; print_linebreaks::Bool)
     function print_omitted_modules(i, j)
         # Find modules involved in intermediate frames and print them
         modules = filter(!isnothing, unique(t[1] |> parentmodule for t ∈ @view trace[i:j]))
-        length(modules) > 0 || return
-        print(io, repeat(' ', ndigits_max + 2))
+        if length(modules) == 0
+            println(io)
+            return
+        end
         for m ∈ modules
             modulecolor = get_modulecolor!(modulecolordict, m, modulecolorcycler)
             printstyled(io, m, color = modulecolor)
@@ -62,16 +64,15 @@ function show_compact_backtrace(io::IO, trace::Vector; print_linebreaks::Bool)
         println(io, "\nStacktrace:")
 
         if is[1] > 1
+            print(io, repeat(' ', ndigits_max + 2) * "⋮ ")
             print_omitted_modules(1, is[1])
-            println(io, repeat(' ', ndigits_max + 2) * "⋮")
         end
 
         lasti = first(is)
         @views for i ∈ is
             if i > lasti + 1
-                println(io, repeat(' ', ndigits_max + 2) * "⋮")
+                print(io, repeat(' ', ndigits_max + 2) * "⋮ ")
                 print_omitted_modules(lasti + 1, i - 1)
-                println(io, repeat(' ', ndigits_max + 2) * "⋮")
             end
             print_stackframe(io, i, trace[i][1], trace[i][2], ndigits_max, modulecolordict, modulecolorcycler)
             if i < num_frames


### PR DESCRIPTION
Saves some space and makes it clearer what the module names refer to