### PR TITLE
Fix missing import

### DIFF
--- a/src/AbbreviatedStackTraces.jl
+++ b/src/AbbreviatedStackTraces.jl
@@ -26,6 +26,7 @@ import Base:
     show_datatype,
     show_exception_stack,
     show_full_backtrace,
+    show_reduced_backtrace,
     show_tuple_as_call,
     show_type_name,
     StackFrame,


### PR DESCRIPTION
From time to time (I guess on longer backtraces) I ran into an
```julia
UndefVarError: show_reduced_backtrace not defined
```

This import fixed it