### PR TITLE
Import Base.stacktrace

### DIFF
--- a/src/override-client.jl
+++ b/src/override-client.jl
@@ -2,7 +2,8 @@ import Base:
     display_error,
     printstyled,
     scrub_repl_backtrace,
-    show_exception_stack
+    show_exception_stack,
+    stacktrace
 
 function scrub_repl_backtrace(bt)
     if bt !== nothing && !(bt isa Vector{Any}) # ignore our sentinel value types


### PR DESCRIPTION
This is needed by `scrub_repl_backtrace()`, otherwise it will crash with a MethodError. I noticed it when upgrading from v0.1.7 to v0.1.8; any time an error was meant to be shown it would instead print:
```julia
julia> env

SYSTEM (REPL): showing an error caused an error

SYSTEM (REPL): caught exception of type MethodError while trying to handle a nested exception; giving up
```

This is on 1.9 beta4:
```julia
julia> versioninfo()
Julia Version 1.9.0-beta4
Commit b75ddb787ff (2023-02-07 21:53 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 12 × Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake)
  Threads: 1 on 12 virtual cores
```